### PR TITLE
Add metrics to bulkhead, breaker, and HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ go run ./examples
 
 The HTTP client in the example uses `fasthttp` and can be configured with a circuit breaker and/or a bulkhead using simple configuration structs. The client itself is created from a `Config` that builds the breaker and bulkhead for you. The circuit breaker supports a half-open state with configurable trial requests and duration. You can also tune the underlying client via `HTTPClientConfig`.
 
+Each component exposes lightweight metrics via a `Metrics()` method. Use these to inspect client request counts and breaker or bulkhead activity within your application.
+
 A GitHub Actions workflow automatically tags commits on the `main` branch so the module can be imported using versioned releases.

--- a/bulkhead/bulkhead.go
+++ b/bulkhead/bulkhead.go
@@ -1,13 +1,24 @@
 package bulkhead
 
-import "errors"
+import (
+	"errors"
+	"sync/atomic"
+)
 
 // ErrFull is returned when the concurrency limit is exceeded.
 var ErrFull = errors.New("bulkhead full")
 
 // Bulkhead limits the number of concurrent executions.
 type Bulkhead struct {
-	sem chan struct{}
+	sem         chan struct{}
+	execCount   uint64
+	rejectCount uint64
+}
+
+// Metrics holds counters for bulkhead activity.
+type Metrics struct {
+	Executed uint64
+	Rejected uint64
 }
 
 // Builder constructs a Bulkhead.
@@ -35,9 +46,19 @@ func (b *Builder) Build() *Bulkhead {
 func (bh *Bulkhead) Execute(fn func() error) error {
 	select {
 	case bh.sem <- struct{}{}:
+		atomic.AddUint64(&bh.execCount, 1)
 		defer func() { <-bh.sem }()
 		return fn()
 	default:
+		atomic.AddUint64(&bh.rejectCount, 1)
 		return ErrFull
+	}
+}
+
+// Metrics returns current counters for the bulkhead.
+func (bh *Bulkhead) Metrics() Metrics {
+	return Metrics{
+		Executed: atomic.LoadUint64(&bh.execCount),
+		Rejected: atomic.LoadUint64(&bh.rejectCount),
 	}
 }

--- a/circuitbreaker/circuitbreaker.go
+++ b/circuitbreaker/circuitbreaker.go
@@ -3,6 +3,7 @@ package circuitbreaker
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -47,6 +48,24 @@ type CircuitBreaker struct {
 	trialStart    time.Time
 	state         State
 	onStateChange func(State)
+
+	successCount uint64
+	failureCount uint64
+	rejectCount  uint64
+	opened       uint64
+	halfOpened   uint64
+	closed       uint64
+}
+
+// Metrics holds counters for circuit breaker activity.
+type Metrics struct {
+	Successes  uint64
+	Failures   uint64
+	Rejected   uint64
+	Opened     uint64
+	HalfOpened uint64
+	Closed     uint64
+	State      State
 }
 
 // Builder constructs a CircuitBreaker.
@@ -118,6 +137,14 @@ func (b *Builder) Build() *CircuitBreaker {
 
 func (cb *CircuitBreaker) setState(s State) {
 	if cb.state != s {
+		switch s {
+		case Open:
+			atomic.AddUint64(&cb.opened, 1)
+		case HalfOpen:
+			atomic.AddUint64(&cb.halfOpened, 1)
+		case Closed:
+			atomic.AddUint64(&cb.closed, 1)
+		}
 		cb.state = s
 		if cb.onStateChange != nil {
 			cb.onStateChange(s)
@@ -139,10 +166,16 @@ func (cb *CircuitBreaker) Execute(fn func() error) error {
 	cb.mu.Unlock()
 
 	if state == Open {
+		atomic.AddUint64(&cb.rejectCount, 1)
 		return ErrOpen
 	}
 
 	err := fn()
+	if err != nil {
+		atomic.AddUint64(&cb.failureCount, 1)
+	} else {
+		atomic.AddUint64(&cb.successCount, 1)
+	}
 
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
@@ -206,4 +239,20 @@ func (cb *CircuitBreaker) startOpenTimer() {
 		cb.trialStart = time.Now()
 		cb.trialCount = 0
 	})
+}
+
+// Metrics returns current counters and state.
+func (cb *CircuitBreaker) Metrics() Metrics {
+	cb.mu.Lock()
+	state := cb.state
+	cb.mu.Unlock()
+	return Metrics{
+		Successes:  atomic.LoadUint64(&cb.successCount),
+		Failures:   atomic.LoadUint64(&cb.failureCount),
+		Rejected:   atomic.LoadUint64(&cb.rejectCount),
+		Opened:     atomic.LoadUint64(&cb.opened),
+		HalfOpened: atomic.LoadUint64(&cb.halfOpened),
+		Closed:     atomic.LoadUint64(&cb.closed),
+		State:      state,
+	}
 }

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -276,6 +277,17 @@ type Client struct {
 	HTTP *fasthttp.Client
 	CB   *circuitbreaker.CircuitBreaker
 	BH   *bulkhead.Bulkhead
+
+	reqCount     uint64
+	successCount uint64
+	errorCount   uint64
+}
+
+// Metrics holds counters for client calls.
+type Metrics struct {
+	Requests  uint64
+	Successes uint64
+	Errors    uint64
 }
 
 // New creates a Client from the provided configuration.
@@ -313,6 +325,7 @@ func NewPlain(httpCfg *HTTPClientConfig) *Client {
 
 // Call sends the request through the breaker and bulkhead and returns a response.
 func (c *Client) Call(ctx context.Context, req Request) (Response, error) {
+	atomic.AddUint64(&c.reqCount, 1)
 	u, err := url.Parse(req.URL())
 	if err != nil {
 		return nil, err
@@ -356,9 +369,11 @@ func (c *Client) Call(ctx context.Context, req Request) (Response, error) {
 	}
 
 	if err := c.execute(callFn); err != nil {
+		atomic.AddUint64(&c.errorCount, 1)
 		return &BasicResponse{StatusCodeVal: resp.StatusCode(), BodyBytes: append([]byte(nil), resp.Body()...), HeaderVals: convertHeaders(&resp)}, err
 	}
 
+	atomic.AddUint64(&c.successCount, 1)
 	return &BasicResponse{StatusCodeVal: resp.StatusCode(), BodyBytes: append([]byte(nil), resp.Body()...), HeaderVals: convertHeaders(&resp)}, nil
 }
 
@@ -381,4 +396,13 @@ func convertHeaders(resp *fasthttp.Response) http.Header {
 		h.Add(string(k), string(v))
 	})
 	return h
+}
+
+// Metrics returns counters about client calls.
+func (c *Client) Metrics() Metrics {
+	return Metrics{
+		Requests:  atomic.LoadUint64(&c.reqCount),
+		Successes: atomic.LoadUint64(&c.successCount),
+		Errors:    atomic.LoadUint64(&c.errorCount),
+	}
 }


### PR DESCRIPTION
## Summary
- add Metrics() to bulkhead for executed/rejected counts
- expose circuit breaker success, failure, rejection, and state change metrics
- track request success/error counts on HTTP client
- document metrics support in README

## Testing
- `go vet ./bulkhead ./circuitbreaker ./httpclient`


------
https://chatgpt.com/codex/tasks/task_e_68a36ffbb900833099f6a9285df8f6f0