### PR TITLE
docs: expand readme and add usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,79 @@
 # goresily
 
-Circuit breaker and bulkhead implementations in Go.
+`goresily` provides lightweight implementations of the **circuit breaker** and **bulkhead** patterns and a convenient HTTP client that composes them. It is designed to make building resilient Go services straightforward.
 
-A small example using them with an HTTP client is available under `examples/` and can be run with:
+## Features
+- Circuit breaker with configurable failure thresholds, time windows, open timeout and half‑open trial requests.
+- Bulkhead concurrency limiter to cap the number of simultaneous executions.
+- HTTP client powered by `fasthttp` with optional breaker and bulkhead, configuration helpers and Prometheus metrics.
+- Simple metric structs for introspection or exporting to monitoring systems.
+- Example programs including a microservices tutorial.
 
+## Installation
+
+```bash
+go get goresily
 ```
-go run ./examples
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "net/http"
+    "time"
+
+    "goresily/httpclient"
+)
+
+func main() {
+    client := httpclient.New(&httpclient.Config{
+        HTTP: &httpclient.HTTPClientConfig{
+            Timeout: 5 * time.Second,
+        },
+        Breaker: &httpclient.BreakerConfig{
+            MaxFailures:   3,
+            Window:        30 * time.Second,
+            Timeout:       10 * time.Second,
+            TrialRequests: 2,
+        },
+        Bulkhead: &httpclient.BulkheadConfig{
+            Limit: 5,
+        },
+    })
+
+    req := httpclient.NewBasicRequestBuilder().
+        Method(http.MethodGet).
+        URL("https://example.com/data").
+        Build()
+
+    resp, err := client.Call(context.Background(), req)
+    if err != nil {
+        fmt.Println("call failed:", err)
+        return
+    }
+    fmt.Println("status:", resp.StatusCode())
+}
 ```
 
-The HTTP client in the example uses `fasthttp` and can be configured with a circuit breaker and/or a bulkhead using simple configuration structs. The client itself is created from a `Config` that builds the breaker and bulkhead for you. The circuit breaker supports a half-open state with configurable trial requests and duration. You can also tune the underlying client via `HTTPClientConfig`.
+## Metrics
 
-Each component exposes lightweight metrics via a `Metrics()` method. Use these to inspect client request counts and breaker or bulkhead activity within your application.
+Each component exposes counters for basic insight into behaviour:
 
-A GitHub Actions workflow automatically tags commits on the `main` branch so the module can be imported using versioned releases.
+```go
+m := client.Metrics()
+fmt.Printf("requests: %d errors: %d\n", m.Requests, m.Errors)
+```
+
+Use `client.RegisterPrometheus(nil)` to publish these counters to the default Prometheus registerer.
+
+## Examples
+
+- `examples/` contains a small standalone demo that can be run with:
+  ```bash
+  go run ./examples
+  ```
+- `examples/microservices` provides a full tutorial showcasing the patterns between two services. See its README for step‑by‑step instructions.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,66 @@
+# Usage Guide
+
+This guide shows how to use the individual components provided by `goresily`.
+
+## Circuit Breaker
+
+```go
+cb := circuitbreaker.NewBuilder().
+    MaxFailures(5).
+    Timeout(30 * time.Second).
+    Window(1 * time.Minute).
+    Build()
+
+err := cb.Execute(func() error {
+    // call protected resource
+    return nil
+})
+if err == circuitbreaker.ErrOpen {
+    // breaker is open
+}
+```
+
+## Bulkhead
+
+```go
+bh := bulkhead.NewBuilder().Limit(10).Build()
+
+err := bh.Execute(func() error {
+    // work to be limited
+    return nil
+})
+if err == bulkhead.ErrFull {
+    // rejected because limit reached
+}
+```
+
+## HTTP Client
+
+```go
+client := httpclient.NewWithBreakerAndBulkhead(
+    &httpclient.HTTPClientConfig{Timeout: 2 * time.Second},
+    &httpclient.BreakerConfig{MaxFailures: 3, Timeout: 5 * time.Second},
+    &httpclient.BulkheadConfig{Limit: 2},
+)
+
+req := httpclient.NewBasicRequestBuilder().
+    Method(http.MethodGet).
+    URL("https://example.com").
+    Build()
+
+resp, err := client.Call(context.Background(), req)
+if err != nil {
+    // handle error
+}
+_ = resp
+```
+
+## Running the examples
+
+Try the demo programs to see the components in action:
+
+```bash
+go run ./examples                                   # simple demonstration
+go run ./examples/microservices/server &           # start test server
+go run ./examples/microservices/client             # run client against server
+```


### PR DESCRIPTION
## Summary
- expand README with features, installation, quick-start example, metrics and links to demos
- add dedicated usage guide showing circuit breaker, bulkhead and HTTP client examples

## Testing
- `go test ./...` *(fails: command hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a37783d0508330bc3d37cb6b104338